### PR TITLE
RC paddle updated steps

### DIFF
--- a/guides/paddle-onboarding-guide.mdx
+++ b/guides/paddle-onboarding-guide.mdx
@@ -223,10 +223,13 @@ The hosted web paywall doesn't have to show the same products as the original â€
 
 If you use RevenueCat for entitlement management:
 
-1. Create a Paddle web configuration in the RevenueCat dashboard.
-2. Set purchase tracking to **automatic**, with the `rc_user_id` metadata field.
-3. Import your Paddle products into RevenueCat.
-4. Attach those products to the appropriate entitlement(s).
+1. Create a Paddle web configuration in the [RevenueCat dashboard](https://app.revenuecat.com).
+   1. Select your project \> **Web** \> Add web provider \> Paddle
+   2. Paste in your Paddle API key
+   3. Purchase tracking should be **Automatic**
+   4. Under **App user ID matching** select **Use a custom field** with `rc_user_id` as the field key
+2. Go to **Product catalog** \> **Products** and Import your Paddle products into RevenueCat.
+3. Attach those products to desired entitlement(s).
 
 RevenueCat entitlements take a moment to reflect Paddle purchases. For instant post-purchase UX, check Helium entitlements in addition to RevenueCat â€” the SDK will push RevenueCat to sync as quickly as possible, but Helium's own entitlement is always the fastest source of truth.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Paddle onboarding guide with clearer numbered setup steps for connecting Paddle with RevenueCat, including API key configuration, purchase tracking, and user ID matching.
  * Added documentation for known limitations regarding prepaid card and payment failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to an onboarding guide; no runtime, auth, or data-path changes.
> 
> **Overview**
> The Paddle onboarding guide’s **optional RevenueCat** section is rewritten as a clearer, step-by-step walkthrough instead of a short bullet list.
> 
> It now links to the RevenueCat dashboard and spells out navigation (**Web** → add Paddle, API key, **Automatic** purchase tracking, and **App user ID matching** via custom field `rc_user_id`). Product import and entitlement attachment are split into explicit numbered steps. A minor end-of-file newline was added under known limitations; no product or SDK code changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecd6f9ad121207c27dd476043c69b454e4c8bf64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->