### PR TITLE
Document UIKit customPaywallTraits handling; fix stale API names

### DIFF
--- a/guides/ways-to-show-paywall.mdx
+++ b/guides/ways-to-show-paywall.mdx
@@ -26,7 +26,7 @@ HeliumPaywall(
 
 <Accordion title="Example with PaywallEventHandlers">
   ```swift
-  HeliumPaywallView(
+  HeliumPaywall(
       trigger: "post_onboarding",
       eventHandlers: PaywallEventHandlers()
           .onOpen { event in
@@ -49,6 +49,48 @@ HeliumPaywall(
       Text("Paywall failed to show")
   }
   ```
+</Accordion>
+
+<Accordion title="Keeping customPaywallTraits current when hosting in UIKit">
+  `customPaywallTraits` are captured when the paywall **displays** and then stay fixed for that
+  presentation. In SwiftUI this is handled for you as long as the traits come from state that
+  re-renders the view — the normal way you'd pass dynamic values into a view.
+
+  When you host `HeliumPaywall` in UIKit with a `UIHostingController`, UIKit won't refresh the view
+  for you. If you build the hosting controller ahead of time and update traits before showing it,
+  drive the view from an `ObservableObject` so the latest traits reach the paywall before display:
+
+  ```swift
+  final class PaywallTraitsStore: ObservableObject {
+      @Published var traits: HeliumUserTraits?
+  }
+
+  struct PaywallHost: View {
+      @ObservedObject var store: PaywallTraitsStore
+      let trigger: String
+      var body: some View {
+          HeliumPaywall(
+              trigger: trigger,
+              config: PaywallPresentationConfig(customPaywallTraits: store.traits)
+          ) { paywallNotShownReason in
+              Text("Paywall failed to show")
+          }
+      }
+  }
+
+  // UIKit
+  let store = PaywallTraitsStore()
+  store.traits = initialTraits
+  let vc = UIHostingController(rootView: PaywallHost(store: store, trigger: "onboarding"))
+
+  // Later, before the paywall is displayed:
+  store.traits = freshTraits // reaches the paywall via the refreshed config
+  ```
+
+  <Note>
+    This applies before the paywall is on screen. Once displayed, traits are locked for that
+    presentation — updating the store afterward won't change an already-shown paywall.
+  </Note>
 </Accordion>
 
 #### SwiftUI ViewModifier

--- a/guides/ways-to-show-paywall.mdx
+++ b/guides/ways-to-show-paywall.mdx
@@ -54,7 +54,7 @@ HeliumPaywall(
 <Accordion title="Keeping customPaywallTraits current when hosting in UIKit">
   `customPaywallTraits` are captured when the paywall **displays** and then stay fixed for that
   presentation. In SwiftUI this is handled for you as long as the traits come from state that
-  re-renders the view — the normal way you'd pass dynamic values into a view.
+  re-renders the view. This is the normal way you'd pass dynamic values into a view.
 
   When you host `HeliumPaywall` in UIKit with a `UIHostingController`, UIKit won't refresh the view
   for you. If you build the hosting controller ahead of time and update traits before showing it,
@@ -89,7 +89,7 @@ HeliumPaywall(
 
   <Note>
     This applies before the paywall is on screen. Once displayed, traits are locked for that
-    presentation — updating the store afterward won't change an already-shown paywall.
+    presentation. Updating the store afterward won't change an already-shown paywall.
   </Note>
 </Accordion>
 

--- a/sdk/quickstart-ios.mdx
+++ b/sdk/quickstart-ios.mdx
@@ -466,10 +466,10 @@ Helium.identify.revenueCatAppUserId = Purchases.shared.appUserID
 
 You can also create a custom delegate and implement your own purchase logic. You can look at our [StoreKitDelegate](https://github.com/cloudcaptainai/helium-swift/blob/main/Sources/Helium/HeliumCore/StoreKitDelegate.swift) and [RevenueCatDelegate](https://github.com/cloudcaptainai/helium-swift/blob/main/Sources/HeliumRevenueCat/HeliumRevenueCat.swift) in the SDK for examples (also linked below).
 
-The `HeliumPurchaseDelegate` is defined as follows:
+The `HeliumPaywallDelegate` is defined as follows:
 
 ```swift
-public protocol HeliumPurchaseDelegate: AnyObject {
+public protocol HeliumPaywallDelegate: AnyObject {
     // Execute the purchase of a product given the product ID.
     func makePurchase(productId: String) async -> HeliumPaywallTransactionStatus
 


### PR DESCRIPTION
## Summary

Docs updates alongside helium-swift #296 (trait-staleness follow-ups).

- **New collapsible section** under **iOS → Embedded View** ("Keeping customPaywallTraits current when hosting in UIKit"): explains that `customPaywallTraits` are snapshotted at display and fixed for the presentation, that SwiftUI keeps them current automatically when they come from re-rendering state, and shows the `ObservableObject` + `UIHostingController` pattern for keeping them current before display. This is the target of the new SDK docstring link (`#embedded-view`).
- **Fix stale `HeliumPaywallView` → `HeliumPaywall`** in the embedded example (the type is `HeliumPaywall`).
- **Fix stale `HeliumPurchaseDelegate` → `HeliumPaywallDelegate`** in the iOS quickstart — matches the actual protocol name in the SDK (`HeliumPaywallDelegate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Documentation-only updates for iOS paywall integration: **embedded view** examples now use **`HeliumPaywall`** (replacing the outdated **`HeliumPaywallView`** name), and the iOS quickstart’s custom purchase section references **`HeliumPaywallDelegate`** instead of **`HeliumPurchaseDelegate`**.
> 
> A new accordion under **iOS → Embedded View** documents how **`customPaywallTraits`** are snapshotted at display time and stay fixed for that presentation. It contrasts SwiftUI (traits from re-rendering state) with UIKit hosting via **`UIHostingController`**, and shows an **`ObservableObject`** + **`PaywallPresentationConfig`** pattern so fresh traits reach the paywall **before** it appears—plus a note that updates after display do not change an on-screen paywall.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e49b77d31017cb6cfd05d2a85d894e2f424460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated iOS embedded paywall examples to use the current `HeliumPaywall` API.
  - Added guidance for keeping custom paywall traits updated when presenting through UIKit.
  - Documented paywall event callbacks, including opening, closing, dismissal, purchases, and custom actions.
  - Corrected the delegate name in the iOS quickstart documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->