### PR TITLE
Updated mintlify pages

### DIFF
--- a/guides/paddle-onboarding-guide.mdx
+++ b/guides/paddle-onboarding-guide.mdx
@@ -110,7 +110,7 @@ The hosted web paywall doesn't have to show the same products as the original â€
 
     **Handle the post-purchase return.** When checkout completes, the user is deep-linked back to your app via the success URL. For a smoother handoff, call `Helium.shared.handleURL(url)` from your `onOpenURL` / `application(_:open:)` handler.
 
-    **Add a "Manage Subscription" button** so users can cancel or update payment methods via Paddle's customer portal\*\*:
+    **Add a "Manage Subscription" button** so users can cancel or update payment methods via Paddle's customer portal:
 
     ```swift
     if await Helium.entitlements.hasActivePaddleEntitlement() {
@@ -124,6 +124,14 @@ The hosted web paywall doesn't have to show the same products as the original â€
     } catch {
         print("Failed to open customer portal: \\(error)")
     }
+    ```
+
+    The portal link opens `paddle.net`, where the user enters the email they purchased with, receives a magic link, and lands in the portal. It's the same portal, just with a secure email verification step in front of it, in line with Paddle's recommended flow.
+
+    **Want a pre-authenticated portal link?** If you'd rather skip the paddle.net email verification step and drop users straight into the customer portal, you can generate an authenticated link yourself. Grab the Paddle customer ID from Helium and pass it to the Paddle API to build the link ([Paddle customer portal docs](https://developer.paddle.com/build/customers/integrate-customer-portal/)):
+
+    ```swift
+    let paddleCustomerId = await Helium.shared.getPaddleCustomerId()
     ```
   </Tab>
   <Tab title="Expo 3.4.4+">
@@ -155,7 +163,7 @@ The hosted web paywall doesn't have to show the same products as the original â€
       You do not need to do anything with the links other than forward them to `heliumHandleURL` like shown above. If you are using **Expo Router** you may need to [override the default behavior](https://docs.expo.dev/router/advanced/native-intent/#sending-navigation-events-to-third-party-services).
     </Note>
 
-    **Add a "Manage Subscription" button** so users can cancel or update payment methods via Paddle's customer portal\*\*:
+    **Add a "Manage Subscription" button** so users can cancel or update payment methods via Paddle's customer portal:
 
     ```tsx
     if (await hasActivePaddleEntitlement()) {
@@ -167,6 +175,14 @@ The hosted web paywall doesn't have to show the same products as the original â€
     if (url) {
       await Linking.openURL(url);
     }
+    ```
+
+    The portal link opens `paddle.net`, where the user enters the email they purchased with, receives a magic link, and lands in the portal. It's the same portal â€” just with a secure email verification step in front of it, in line with Paddle's recommended flow.
+
+    **Want a pre-authenticated portal link?** If you'd rather skip the paddle.net email verification step and drop users straight into the customer portal, you can generate an authenticated link yourself. Grab the Paddle customer ID from Helium and pass it to the Paddle SDK to build the link ([Paddle customer portal docs](https://developer.paddle.com/build/customers/integrate-customer-portal/)):
+
+    ```tsx
+    const paddleCustomerId = await getPaddleCustomerId();
     ```
   </Tab>
   <Tab title="Flutter 3.3.4+">
@@ -192,7 +208,7 @@ The hosted web paywall doesn't have to show the same products as the original â€
     });
     ```
 
-    **Add a "Manage Subscription" button** so users can cancel or update payment methods via Paddle's customer portal\*\*:
+    **Add a "Manage Subscription" button** so users can cancel or update payment methods via Paddle's customer portal:
 
     ```dart
     final hasPaddle = await HeliumFlutter().hasActivePaddleEntitlement();
@@ -207,10 +223,12 @@ The hosted web paywall doesn't have to show the same products as the original â€
       await launchUrl(url);
     }
     ```
+
+    The portal link opens `paddle.net`, where the user enters the email they purchased with, receives a magic link, and lands in the portal. It's the same portal â€” just with a secure email verification step in front of it, in line with Paddle's recommended flow.
+
+    **Want a pre-authenticated portal link?** If you'd rather skip the paddle.net email verification step and drop users straight into the customer portal, you can generate an authenticated link yourself. Grab the Paddle customer ID from Helium and pass it to the Paddle SDK to build the link ([Paddle customer portal docs](https://developer.paddle.com/build/customers/integrate-customer-portal/)).
   </Tab>
 </Tabs>
-
-\*\*The Helium SDK will return an unauthenticated link as Paddle customer portal, so your users will have to provide email and log in. For a smoother experience, we recommend creating a [pre-authenticated link](https://developer.paddle.com/build/customers/integrate-customer-portal/).
 
 ### 8. (Optional) Connect RevenueCat
 

--- a/guides/paddle-onboarding-guide.mdx
+++ b/guides/paddle-onboarding-guide.mdx
@@ -126,13 +126,15 @@ The hosted web paywall doesn't have to show the same products as the original â€
     }
     ```
 
-    The portal link opens `paddle.net`, where the user enters the email they purchased with, receives a magic link, and lands in the portal. It's the same portal, just with a secure email verification step in front of it, in line with Paddle's recommended flow.
+    The portal link opens `paddle.net`, where the user enters the email they purchased with, receives a magic link, and lands in the customer portal. This is Paddle's default, recommended flow: a secure email verification step in front of the portal.
 
-    **Want a pre-authenticated portal link?** If you'd rather skip the paddle.net email verification step and drop users straight into the customer portal, you can generate an authenticated link yourself. Grab the Paddle customer ID from Helium and pass it to the Paddle API to build the link ([Paddle customer portal docs](https://developer.paddle.com/build/customers/integrate-customer-portal/)):
+    **Want a pre-authenticated portal link?** If you'd rather skip the paddle.net email verification step and drop users straight into the customer portal, generate the link from your backend instead. Look up the user's Paddle customer ID with Helium:
 
     ```swift
     let paddleCustomerId = await Helium.shared.getPaddleCustomerId()
     ```
+
+    Send that ID to your server, then call `POST /customers/{customer_id}/portal-sessions` using a Paddle API key with `customer_portal_session.write` and return `urls.general.overview` to the client ([Paddle customer portal docs](https://developer.paddle.com/build/customers/integrate-customer-portal/)). The returned link contains a temporary session token, so generate a fresh one for each request rather than caching it.
   </Tab>
   <Tab title="Expo 3.4.4+">
     **Enable external web checkout before initializing Helium:**
@@ -177,13 +179,15 @@ The hosted web paywall doesn't have to show the same products as the original â€
     }
     ```
 
-    The portal link opens `paddle.net`, where the user enters the email they purchased with, receives a magic link, and lands in the portal. It's the same portal â€” just with a secure email verification step in front of it, in line with Paddle's recommended flow.
+    The portal link opens `paddle.net`, where the user enters the email they purchased with, receives a magic link, and lands in the customer portal. This is Paddle's default, recommended flow: a secure email verification step in front of the portal.
 
-    **Want a pre-authenticated portal link?** If you'd rather skip the paddle.net email verification step and drop users straight into the customer portal, you can generate an authenticated link yourself. Grab the Paddle customer ID from Helium and pass it to the Paddle SDK to build the link ([Paddle customer portal docs](https://developer.paddle.com/build/customers/integrate-customer-portal/)):
+    **Want a pre-authenticated portal link?** If you'd rather skip the paddle.net email verification step and drop users straight into the customer portal, generate the link from your backend instead. Look up the user's Paddle customer ID with Helium:
 
     ```tsx
     const paddleCustomerId = await getPaddleCustomerId();
     ```
+
+    Send that ID to your server, then call `POST /customers/{customer_id}/portal-sessions` using a Paddle API key with `customer_portal_session.write` and return `urls.general.overview` to the client ([Paddle customer portal docs](https://developer.paddle.com/build/customers/integrate-customer-portal/)). The returned link contains a temporary session token, so generate a fresh one for each request rather than caching it.
   </Tab>
   <Tab title="Flutter 3.3.4+">
     **Enable external web checkout before initializing Helium:**
@@ -224,9 +228,9 @@ The hosted web paywall doesn't have to show the same products as the original â€
     }
     ```
 
-    The portal link opens `paddle.net`, where the user enters the email they purchased with, receives a magic link, and lands in the portal. It's the same portal â€” just with a secure email verification step in front of it, in line with Paddle's recommended flow.
+    The portal link opens `paddle.net`, where the user enters the email they purchased with, receives a magic link, and lands in the customer portal. This is Paddle's default, recommended flow: a secure email verification step in front of the portal.
 
-    **Want a pre-authenticated portal link?** If you'd rather skip the paddle.net email verification step and drop users straight into the customer portal, you can generate an authenticated link yourself. Grab the Paddle customer ID from Helium and pass it to the Paddle SDK to build the link ([Paddle customer portal docs](https://developer.paddle.com/build/customers/integrate-customer-portal/)).
+    **Want a pre-authenticated portal link?** If you'd rather skip the paddle.net email verification step and drop users straight into the customer portal, generate the link from your backend instead. Look up the user's Paddle customer ID with Helium's `getPaddleCustomerId()`, send it to your server, then call `POST /customers/{customer_id}/portal-sessions` using a Paddle API key with `customer_portal_session.write` and return `urls.general.overview` to the client ([Paddle customer portal docs](https://developer.paddle.com/build/customers/integrate-customer-portal/)). The returned link contains a temporary session token, so generate a fresh one for each request rather than caching it.
   </Tab>
 </Tabs>
 

--- a/guides/paddle-onboarding-guide.mdx
+++ b/guides/paddle-onboarding-guide.mdx
@@ -134,7 +134,7 @@ The hosted web paywall doesn't have to show the same products as the original â€
     let paddleCustomerId = await Helium.shared.getPaddleCustomerId()
     ```
 
-    Send that ID to your server, then call `POST /customers/{customer_id}/portal-sessions` using a Paddle API key with `customer_portal_session.write` and return `urls.general.overview` to the client ([Paddle customer portal docs](https://developer.paddle.com/build/customers/integrate-customer-portal/)). The returned link contains a temporary session token, so generate a fresh one for each request rather than caching it.
+    Send that ID to your server and follow [Paddle's guide for generating pre-authenticated customer portal links](https://developer.paddle.com/build/customers/integrate-customer-portal/).
   </Tab>
   <Tab title="Expo 3.4.4+">
     **Enable external web checkout before initializing Helium:**
@@ -187,7 +187,7 @@ The hosted web paywall doesn't have to show the same products as the original â€
     const paddleCustomerId = await getPaddleCustomerId();
     ```
 
-    Send that ID to your server, then call `POST /customers/{customer_id}/portal-sessions` using a Paddle API key with `customer_portal_session.write` and return `urls.general.overview` to the client ([Paddle customer portal docs](https://developer.paddle.com/build/customers/integrate-customer-portal/)). The returned link contains a temporary session token, so generate a fresh one for each request rather than caching it.
+    Send that ID to your server and follow [Paddle's guide for generating pre-authenticated customer portal links](https://developer.paddle.com/build/customers/integrate-customer-portal/).
   </Tab>
   <Tab title="Flutter 3.3.4+">
     **Enable external web checkout before initializing Helium:**
@@ -230,7 +230,7 @@ The hosted web paywall doesn't have to show the same products as the original â€
 
     The portal link opens `paddle.net`, where the user enters the email they purchased with, receives a magic link, and lands in the customer portal. This is Paddle's default, recommended flow: a secure email verification step in front of the portal.
 
-    **Want a pre-authenticated portal link?** If you'd rather skip the paddle.net email verification step and drop users straight into the customer portal, generate the link from your backend instead. Look up the user's Paddle customer ID with Helium's `getPaddleCustomerId()`, send it to your server, then call `POST /customers/{customer_id}/portal-sessions` using a Paddle API key with `customer_portal_session.write` and return `urls.general.overview` to the client ([Paddle customer portal docs](https://developer.paddle.com/build/customers/integrate-customer-portal/)). The returned link contains a temporary session token, so generate a fresh one for each request rather than caching it.
+    **Want a pre-authenticated portal link?** If you'd rather skip the paddle.net email verification step and drop users straight into the customer portal, generate the link from your backend instead. Look up the user's Paddle customer ID with Helium's `getPaddleCustomerId()`, send it to your server, and follow [Paddle's guide for generating pre-authenticated customer portal links](https://developer.paddle.com/build/customers/integrate-customer-portal/).
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
- Updated guides/paddle-onboarding-guide.mdx

Mintlify-Source: dashboard-editor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to a Mintlify guide; no runtime, auth, or data-path changes.
> 
> **Overview**
> Updates **`guides/paddle-onboarding-guide.mdx`** for the iOS, Expo, and Flutter SDK tabs in the “Manage Subscription” / customer portal section.
> 
> Fixes a markdown typo on the **Manage Subscription** heading (stray `\*\*`). After each `createPaddlePortalSession` example, adds prose on Paddle’s **default** portal flow (`paddle.net` → email → magic link → portal) and a **pre-authenticated** path using `getPaddleCustomerId()` (or platform equivalents) plus Paddle’s backend portal-link docs.
> 
> Removes the old single note below the tabs that only said SDK links are unauthenticated and pointed at pre-auth; that guidance is now inline per platform instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c694016c7d13a69ed26a065dd5854b91a0a6164c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated iOS, Expo, and Flutter “Manage Subscription” customer-portal instructions, correcting “Manage Subscription” button text formatting.
  * Clarified Paddle’s default customer-portal flow on each platform (email entry → magic link → portal).
  * Added platform-specific steps for generating pre-authenticated customer-portal links, including the recommended process to obtain the customer ID and generate a new link per request.
  * Removed outdated cross-platform guidance in favor of the new per-platform instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->