### PR TITLE
Simplify ASSN forwarding examples to drop-in snippets

### DIFF
--- a/guides/revenue-reporting.mdx
+++ b/guides/revenue-reporting.mdx
@@ -66,7 +66,7 @@ try {
 // App Router:   const body = await request.json();
 // Pages Router: const body = req.body;
 try {
-  await fetch(
+  const response = await fetch(
     'your-helium-webhook-url-here',
     {
       method: 'POST',
@@ -75,6 +75,7 @@ try {
       signal: AbortSignal.timeout(5000)
     }
   );
+  if (!response.ok) throw new Error(`Helium returned ${response.status}`);
 } catch (error) {
   console.error('Failed to forward webhook to Helium:', error);
 }
@@ -101,7 +102,11 @@ func() {
 		log.Printf("Failed to forward webhook to Helium: %v", err)
 		return
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		log.Printf("Failed to forward webhook to Helium: status %d", resp.StatusCode)
+	}
 }()
 ```
 
@@ -109,12 +114,13 @@ func() {
 ```python Python w/ Flask
 # Inside your existing route, near the top:
 try:
-    requests.post(
+    response = requests.post(
         'your-helium-webhook-url-here',
         json=request.json,
         headers={'Content-Type': 'application/json'},
         timeout=5
     )
+    response.raise_for_status()
 except requests.exceptions.RequestException as e:
     print(f'Failed to forward webhook to Helium: {e}')
 ```
@@ -125,12 +131,13 @@ except requests.exceptions.RequestException as e:
 # body = await request.json()
 try:
     async with httpx.AsyncClient(timeout=5.0) as client:
-        await client.post(
+        response = await client.post(
             'your-helium-webhook-url-here',
             json=body,
             headers={'Content-Type': 'application/json'}
         )
-except httpx.RequestError as e:
+        response.raise_for_status()
+except httpx.HTTPError as e:
     print(f'Failed to forward webhook to Helium: {e}')
 ```
 

--- a/guides/revenue-reporting.mdx
+++ b/guides/revenue-reporting.mdx
@@ -36,12 +36,9 @@ Use RevenueCat webhooks to send revenue events to Helium. Follow the instruction
 
 Grab the **Webhook URL** from the **App Store Server Notifications** section and use that value in your forwarding code.
 
-In your existing App Store Server Notifications handler, add a snippet that forwards the payload to Helium. Place it **as early as possible** — after you've parsed the incoming body, but before any type filtering or early returns — so that Helium receives *every* notification type, not just the subset your own handler acts on.
+In your existing App Store Server Notifications handler, add a snippet that forwards the payload to Helium **unchanged**. Place it as early as possible — after you've parsed the incoming body, but before any type filtering or early returns — so that Helium receives *every* notification type, not just the subset your own handler acts on.
 
-A few things to keep in mind:
-
-- **Don't couple your response to the forward.** Await the forward and wrap it in a `try/catch` that only logs on failure. It should never throw or change the status you return to Apple — otherwise a hiccup forwarding to Helium would make Apple retry the whole notification and re-run your own handling.
-- **Forward the payload intact.** You can forward the already-parsed body as-is; re-serializing it to JSON is fine because Helium verifies Apple's signed payload, not the raw request bytes. Just don't unwrap, extract, or otherwise modify it.
+**Don't couple your response to the forward.** Await the forward and wrap it in a `try/catch` that only logs on failure. It should never throw or change the status you return to Apple — otherwise a hiccup forwarding to Helium would make Apple retry the whole notification and re-run your own handling.
 
 Here is some example forwarding code. Reach out to Helium support if you have any questions.
 

--- a/guides/revenue-reporting.mdx
+++ b/guides/revenue-reporting.mdx
@@ -75,7 +75,9 @@ try {
       signal: AbortSignal.timeout(5000)
     }
   );
-  if (!response.ok) throw new Error(`Helium returned ${response.status}`);
+  if (!response.ok) {
+    console.error(`Failed to forward webhook to Helium: status ${response.status}`);
+  }
 } catch (error) {
   console.error('Failed to forward webhook to Helium:', error);
 }

--- a/guides/revenue-reporting.mdx
+++ b/guides/revenue-reporting.mdx
@@ -36,156 +36,100 @@ Use RevenueCat webhooks to send revenue events to Helium. Follow the instruction
 
 Grab the **Webhook URL** from the **App Store Server Notifications** section and use that value in your forwarding code.
 
-Wherever you consume webhook events for App Store Server Notifications, you'll want to add a snippet of code that forwards the exact, unmodified ASSN payload to Helium.
+In your existing App Store Server Notifications handler, add a snippet that forwards the payload to Helium. Place it **as early as possible** — after you've parsed the incoming body, but before any type filtering or early returns — so that Helium receives *every* notification type, not just the subset your own handler acts on.
+
+A few things to keep in mind:
+
+- **Don't couple your response to the forward.** Await the forward and wrap it in a `try/catch` that only logs on failure. It should never throw or change the status you return to Apple — otherwise a hiccup forwarding to Helium would make Apple retry the whole notification and re-run your own handling.
+- **Forward the payload intact.** You can forward the already-parsed body as-is; re-serializing it to JSON is fine because Helium verifies Apple's signed payload, not the raw request bytes. Just don't unwrap, extract, or otherwise modify it.
 
 Here is some example forwarding code. Reach out to Helium support if you have any questions.
 
 <CodeGroup>
 
 ```javascript Node/Express
-const express = require('express');
-const axios = require('axios');
-const app = express();
-
-app.use(express.json());
-
-app.post('/assn-webhook', async (req, res) => {
-  try {
-    const response = await axios.post(
-      'your-helium-webhook-url-here',
-      req.body,
-      {
-        headers: { 'Content-Type': 'application/json' },
-        timeout: 5000
-      }
-    );
-
-    console.log('Successfully forwarded webhook');
-    res.status(200).json({ success: true });
-  } catch (error) {
-    console.error('Failed to forward webhook:', error.message);
-    res.status(500).json({ error: 'Failed to forward webhook' });
-  }
-});
+// Inside your existing app.post(...) ASSN handler, near the top:
+try {
+  await axios.post(
+    'your-helium-webhook-url-here',
+    req.body,
+    {
+      headers: { 'Content-Type': 'application/json' },
+      timeout: 5000
+    }
+  );
+} catch (error) {
+  console.error('Failed to forward webhook to Helium:', error.message);
+}
 ```
 
 
 ```javascript Next.js Pages Router
-export default async function handler(req, res) {
-  if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
-  }
-
-  try {
-    const response = await fetch(
-      'your-helium-webhook-url-here',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(req.body),
-        signal: AbortSignal.timeout(5000)
-      }
-    );
-
-    if (response.ok) {
-      console.log('Successfully forwarded webhook');
-      return res.status(200).json({ success: true });
-    } else {
-      throw new Error(`HTTP ${response.status}`);
+// Inside your existing handler, near the top (req.body is already parsed):
+try {
+  await fetch(
+    'your-helium-webhook-url-here',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req.body),
+      signal: AbortSignal.timeout(5000)
     }
-  } catch (error) {
-    console.error('Failed to forward webhook:', error);
-    return res.status(500).json({ error: 'Failed to forward webhook' });
-  }
+  );
+} catch (error) {
+  console.error('Failed to forward webhook to Helium:', error);
 }
 ```
 
 
 ```javascript Next.js App Router
-import { NextResponse } from 'next/server';
-
-export async function POST(request) {
-  try {
-    const body = await request.json();
-
-    const response = await fetch(
-      'your-helium-webhook-url-here',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(5000)
-      }
-    );
-
-    if (response.ok) {
-      console.log('Successfully forwarded webhook');
-      return NextResponse.json({ success: true });
-    } else {
-      throw new Error(`HTTP ${response.status}`);
+// Inside your existing POST handler, right after you read the body:
+// const body = await request.json();
+try {
+  await fetch(
+    'your-helium-webhook-url-here',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(5000)
     }
-  } catch (error) {
-    console.error('Failed to forward webhook:', error);
-    return NextResponse.json(
-      { error: 'Failed to forward webhook' },
-      { status: 500 }
-    );
-  }
+  );
+} catch (error) {
+  console.error('Failed to forward webhook to Helium:', error);
 }
 ```
 
 
 ```python Python w/ Flask
-@app.route('/webhook', methods=['POST'])
-def forward_webhook():
-    try:
-        response = requests.post(
-            'your-helium-webhook-url-here',
-            json=request.json,
-            headers={'Content-Type': 'application/json'},
-            timeout=5
-        )
-        response.raise_for_status()
-
-        print('Successfully forwarded webhook')
-        return jsonify({'success': True}), 200
-
-    except requests.exceptions.RequestException as e:
-        print(f'Failed to forward webhook: {e}')
-        return jsonify({'error': 'Failed to forward webhook'}), 500
+# Inside your existing route, near the top:
+try:
+    requests.post(
+        'your-helium-webhook-url-here',
+        json=request.json,
+        headers={'Content-Type': 'application/json'},
+        timeout=5
+    )
+except requests.exceptions.RequestException as e:
+    print(f'Failed to forward webhook to Helium: {e}')
 ```
 
 
 ```python Python w/ FastAPI
-@app.post('/webhook')
-async def forward_webhook(request: Request):
-    try:
-        body = await request.json()
-
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            response = await client.post(
-                'your-helium-webhook-url-here',
-                json=body,
-                headers={'Content-Type': 'application/json'}
-            )
-            response.raise_for_status()
-
-        print('Successfully forwarded webhook')
-        return {'success': True}
-
-    except (httpx.RequestError, httpx.HTTPStatusError) as e:
-        print(f'Failed to forward webhook: {e}')
-        raise HTTPException(
-            status_code=500,
-            detail='Failed to forward webhook'
+# Inside your existing handler, right after you read the body:
+# body = await request.json()
+try:
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        await client.post(
+            'your-helium-webhook-url-here',
+            json=body,
+            headers={'Content-Type': 'application/json'}
         )
+except httpx.RequestError as e:
+    print(f'Failed to forward webhook to Helium: {e}')
 ```
 
 </CodeGroup>
-
-<Tip>
-  You may want to extract the pk value from the Webhook URL as an environment variable to avoid storing in version control.
-</Tip>
 
 ## Configure Android
 

--- a/guides/revenue-reporting.mdx
+++ b/guides/revenue-reporting.mdx
@@ -40,7 +40,7 @@ In your existing App Store Server Notifications handler, add a snippet that forw
 
 **Don't couple your response to the forward.** Await the forward and wrap it in a `try/catch` that only logs on failure. It should never throw or change the status you return to Apple — otherwise a hiccup forwarding to Helium would make Apple retry the whole notification and re-run your own handling.
 
-Here is some example forwarding code. Reach out to Helium support if you have any questions.
+Forwarding is just a POST — send the request body to your Helium Webhook URL with `Content-Type: application/json`. The examples below cover a few common stacks, but any language works. Reach out to Helium support if you have any questions.
 
 <CodeGroup>
 
@@ -61,27 +61,10 @@ try {
 ```
 
 
-```javascript Next.js Pages Router
-// Inside your existing handler, near the top (req.body is already parsed):
-try {
-  await fetch(
-    'your-helium-webhook-url-here',
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(req.body),
-      signal: AbortSignal.timeout(5000)
-    }
-  );
-} catch (error) {
-  console.error('Failed to forward webhook to Helium:', error);
-}
-```
-
-
-```javascript Next.js App Router
+```javascript Next.js
 // Inside your existing POST handler, right after you read the body:
-// const body = await request.json();
+// App Router:   const body = await request.json();
+// Pages Router: const body = req.body;
 try {
   await fetch(
     'your-helium-webhook-url-here',
@@ -95,6 +78,31 @@ try {
 } catch (error) {
   console.error('Failed to forward webhook to Helium:', error);
 }
+```
+
+
+```go Go
+// Inside your existing handler, after reading the request body into `body`
+// (a []byte holding the raw JSON payload), near the top:
+func() {
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		"your-helium-webhook-url-here", bytes.NewReader(body))
+	if err != nil {
+		log.Printf("Failed to forward webhook to Helium: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Printf("Failed to forward webhook to Helium: %v", err)
+		return
+	}
+	resp.Body.Close()
+}()
 ```
 
 


### PR DESCRIPTION
Reworks the **Forward App Store Server Notifications** section of `guides/revenue-reporting.mdx` after reviewing the sample code against how the webhook is actually handled in `content-manager-lite` (`app/api/webhooks/app-store-notifications/route.ts`).

The examples were correct but framed as standalone handlers with response plumbing, which invited a real footgun when dropped into an existing handler. This tightens them.

## Changes

- **Snippet-only.** Removed the standalone-handler scaffolding and all response plumbing (`res.status(...)` / `NextResponse.json(...)` / `raise HTTPException`). Each example is now just the awaited forward in a `try/catch` that logs on failure — meant to drop into an existing ASSN handler. (Anyone without an existing handler should just point App Store Server Notifications straight at Helium instead of forwarding.)
- **Placement guidance.** Added a note to place the forward as early as possible — after the body is parsed, but before any type filtering or early returns — so Helium receives *every* notification type, not just the subset the implementer's own handler acts on.
- **Decoupled from the response to Apple.** Documented that the forward should only log on failure and never change the status returned to Apple; otherwise a transient forwarding error makes Apple retry the whole notification and re-run the implementer's own handling.
- **Payload forwarded unchanged.** The intro now says to forward the payload "unchanged." Re-serializing the parsed body is safe because Helium verifies Apple's signed payload (the self-contained JWS), not the raw request bytes.
- **Dropped the `pk`-as-env-var tip.** The full Webhook URL can be pasted directly; the `pk` isn't credential-grade (a forged request fails Apple's signature verification on our end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmQJF2QrWbCUnDCnw5azL3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to integration examples; no runtime or security-sensitive code paths.
> 
> **Overview**
> Updates **`guides/revenue-reporting.mdx`** for **Forward App Store Server Notifications** so integrators paste forwarding code into an existing handler instead of copying full webhook endpoints.
> 
> The prose now stresses forwarding the body **unchanged**, running the forward **early** (after parse, before type filters or early returns), and **decoupling** it from the HTTP response to Apple—`try/catch` with logging only, no 500s from a failed Helium POST. Standalone Express/Next/FastAPI handlers and success/error response plumbing are removed; examples are short snippets for Node/Express, a combined Next.js block, **Go**, Flask, and FastAPI. The tip about storing `pk` in env vars is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df222b4653edcec93f35ba5c4d737627cbd1abe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated App Store Server Notifications guidance to forward payloads to Helium unchanged and as early as possible.
  * Clarified that forwarding should be awaited and handled independently from Apple’s response.
  * Added framework-specific examples showing failures are logged without altering notification response status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->