### PR TITLE
Improve Paddle and Stripe App2Web testing docs

### DIFF
--- a/guides/app2web-go-live-checklist.mdx
+++ b/guides/app2web-go-live-checklist.mdx
@@ -1,0 +1,33 @@
+---
+title: "App2Web Go-Live Checklist"
+description: "A short checklist for testing your App2Web flow before launch."
+---
+
+App2Web uses two linked paywalls: one shown in the app and one shown in the browser. Complete QA for your normal in-app purchase path before testing App2Web.
+
+<Note>
+  When the in-app App2Web paywall triggers a purchase action for a web product, Helium opens the linked hosted web paywall in the browser. The purchase is completed on the web, not in the app.
+</Note>
+
+## Check the setup
+
+- [ ] The in-app App2Web paywall and hosted web paywall are linked and published.
+- [ ] The hosted web paywall is reached only through the in-app App2Web flow, not directly from a workflow.
+- [ ] Web products are attached correctly, and the normal IAP path remains available through `continue in-app`.
+- [ ] Targeting includes only eligible users and has been tested with an internal audience.
+- [ ] Success and cancel URLs, user identity, revenue tracking, and subscription management are configured.
+
+## Test the full flow
+
+- [ ] Open App2Web through a real trigger on a physical device. Triple-tap does not test the full flow.
+- [ ] Tapping the web purchase CTA opens the linked hosted web paywall in the browser.
+- [ ] The product selected in the app is the product selected on the hosted web paywall.
+- [ ] Product selection and the web purchase action are separate, so the CTA cannot send the wrong product.
+- [ ] `continue in-app` opens the intended IAP purchase path.
+- [ ] Dismissing or abandoning web checkout returns the user to the expected place without granting access.
+- [ ] Complete a web purchase and confirm the app reopens with an active entitlement.
+- [ ] Confirm the purchase appears in Helium and your connected revenue or entitlement system.
+
+## Launch
+
+- [ ] Start with a small eligible audience and confirm the flow is healthy before expanding traffic.

--- a/guides/paddle-onboarding-guide.mdx
+++ b/guides/paddle-onboarding-guide.mdx
@@ -289,3 +289,4 @@ Deep links are specific to your app build, so it's cleaner to configure them alo
 - **California compliance** for subscription cancellation: guidance coming soon.
 - **Publish states:** both the original paywall and its linked hosted web paywall must be published before the flow works end-to-end.
 - **Localizations:** hosted web paywalls currently support one language.
+- **Testing:** normally, paywalls should be tested with the triple-tap viewer. Triple-tap does not currently support end-to-end App2Web testing, so test the full App2Web flow through a real trigger.

--- a/guides/paddle-onboarding-guide.mdx
+++ b/guides/paddle-onboarding-guide.mdx
@@ -71,7 +71,6 @@ To offer a free trial on a Paddle product, configure it on the product in Helium
 
 - **One trial per customer, ever.** Paddle doesn't natively prevent trial abuse (a user could start a trial, cancel, and start another), so Helium enforces this at the entitlement layer. Once a customer has held a trial — even if they cancel — they won't be offered another.
 - **A payment method is required up front.** Payment is deferred, not skipped.
-- **Intro pricing** (e.g., \$1.99 for the first 3 months, then \$9.99/mo) is **not yet supported.**
 
 ### 6. Build your paywalls
 
@@ -254,15 +253,19 @@ RevenueCat entitlements take a couple seconds to reflect Paddle purchases. For i
 
 ## Testing
 
-Run through these scenarios in Paddle's sandbox before going live:
+To test without affecting production traffic, create a test targeting group that includes:
 
-1. **Happy path purchase.** Open a Paddle paywall in-app, tap a product, complete checkout in the browser, and confirm you're deep-linked back with an active entitlement.
+- Paddle eligible users
+- `sandbox` or `debug` environment
+
+Target the App2Web paywall to that group, then run through these scenarios in Paddle's sandbox before going live:
+
+1. **Happy path purchase.** Open an App2Web paywall in-app, tap a web product, and confirm the app correctly opens the browser. Complete the standard purchase flow, then confirm you're deep-linked back with an active entitlement. Dismiss the paywall before purchasing as well, and confirm the app returns to the expected screen.
 2. **Entitlement sync.** After purchase, confirm `hasActivePaddleEntitlement()` returns `true` immediately, and that RevenueCat (if connected) updates within a few seconds.
-3. **Free trial.** Purchase a trial product, cancel it, and confirm the trial is no longer offered on re-purchase.
-4. **Cancel flow.** Open the customer portal from your app, cancel a subscription, and confirm the entitlement expires at period end.
-5. **Pre-login purchase.** Make a purchase before setting a user ID. After you set the user ID, confirm the entitlement attaches correctly.
-6. **Abandoned checkout.** Close the browser mid-checkout and confirm the app handles the cancel URL gracefully.
-7. **Webhook delivery.** In the Paddle dashboard, confirm webhooks are reaching Helium with 2xx responses.
+3. **Cancel flow.** Open the customer portal from your app, cancel a subscription, and confirm the entitlement expires at period end.
+4. **Abandoned checkout.** Close the browser mid-checkout and confirm the app handles the cancel URL gracefully.
+5. **Webhook delivery.** In the Paddle dashboard, confirm webhooks are reaching Helium with 2xx responses.
+6. **Pre-login purchase (if applicable).** If your App2Web paywall can be shown before you set a durable `user_id`, make a purchase before setting it. Set the durable user ID afterwards and confirm the entitlement attaches correctly.
 
 ## Appendix
 
@@ -282,8 +285,7 @@ Deep links are specific to your app build, so it's cleaner to configure them alo
 
 ### Known limitations and gotchas
 
-- **Intro pricing** (`$X for first N months, then $Y/mo`) is not yet supported.
+- **Availability:** Paddle App2Web is currently supported for US storefronts only.
 - **California compliance** for subscription cancellation: guidance coming soon.
 - **Publish states:** both the original paywall and its linked hosted web paywall must be published before the flow works end-to-end.
-- **Localizations:** if you support multiple languages in-app, confirm your hosted web paywall's localizations match.
-- **Prepaid card failures / declined payments:** the user is returned via the `cancelURL`. Your app should treat this as "no purchase made."
+- **Localizations:** hosted web paywalls currently support one language.

--- a/guides/paddle-onboarding-guide.mdx
+++ b/guides/paddle-onboarding-guide.mdx
@@ -290,3 +290,7 @@ Deep links are specific to your app build, so it's cleaner to configure them alo
 - **Publish states:** both the original paywall and its linked hosted web paywall must be published before the flow works end-to-end.
 - **Localizations:** hosted web paywalls currently support one language.
 - **Testing:** normally, paywalls should be tested with the triple-tap viewer. Triple-tap does not currently support end-to-end App2Web testing, so test the full App2Web flow through a real trigger.
+
+## Before you go live
+
+Run through the [App2Web go-live checklist](/guides/app2web-go-live-checklist) before sending traffic to this flow.

--- a/guides/stripe-onboarding-guide.mdx
+++ b/guides/stripe-onboarding-guide.mdx
@@ -222,14 +222,18 @@ If you use [RevenueCat alongside Stripe](https://www.revenuecat.com/docs/web/int
 
 ## Testing
 
-Run through these scenarios before going live:
+To test without affecting production traffic, create a test targeting group that includes:
 
-1. **Happy path purchase.** Open a Stripe paywall in-app, tap a product, complete checkout in the browser, and confirm you're deep-linked back with an active entitlement.
+- Stripe eligible users
+- `sandbox` or `debug` environment
+
+Target the App2Web paywall to that group, then run through these scenarios before going live:
+
+1. **Happy path purchase.** Open an App2Web paywall in-app, tap a web product, and confirm the app correctly opens the browser. Complete the standard purchase flow, then confirm you're deep-linked back with an active entitlement. Dismiss the paywall before purchasing as well, and confirm the app returns to the expected screen.
 2. **Entitlement sync.** After purchase, confirm `hasActiveStripeEntitlement()` returns `true` immediately, and that RevenueCat (if connected) updates within a few seconds.
-3. **Free trial.** Purchase a trial product, cancel it, and confirm the trial is no longer offered on re-purchase.
-4. **Cancel flow.** Open the customer portal from your app, cancel a subscription, and confirm the entitlement expires at period end.
-5. **Pre-login purchase.** Make a purchase before setting a user ID. After you set the user ID, confirm the entitlement attaches correctly.
-6. **Abandoned checkout.** Close the browser mid-checkout and confirm the app handles the cancel URL gracefully.
+3. **Cancel flow.** Open the customer portal from your app, cancel a subscription, and confirm the entitlement expires at period end.
+4. **Abandoned checkout.** Close the browser mid-checkout and confirm the app handles the cancel URL gracefully.
+5. **Pre-login purchase (if applicable).** If your App2Web paywall can be shown before you set a durable `user_id`, make a purchase before setting it. Set the durable user ID afterwards and confirm the entitlement attaches correctly.
 
 ## Appendix
 
@@ -249,6 +253,6 @@ Deep links are specific to your app build, so it's cleaner to configure them alo
 
 ### Known limitations and gotchas
 
+- **Availability:** Stripe App2Web is currently supported for US storefronts only.
 - **Publish states:** both the original paywall and its linked hosted web paywall must be published before the flow works end-to-end.
-- **Localizations:** if you support multiple languages in-app, confirm your hosted web paywall's localizations match.
-- **Declined payments:** the user is returned via the `cancelURL`. Your app should treat this as "no purchase made."
+- **Localizations:** hosted web paywalls currently support one language.

--- a/guides/stripe-onboarding-guide.mdx
+++ b/guides/stripe-onboarding-guide.mdx
@@ -257,3 +257,7 @@ Deep links are specific to your app build, so it's cleaner to configure them alo
 - **Publish states:** both the original paywall and its linked hosted web paywall must be published before the flow works end-to-end.
 - **Localizations:** hosted web paywalls currently support one language.
 - **Testing:** normally, paywalls should be tested with the triple-tap viewer. Triple-tap does not currently support end-to-end App2Web testing, so test the full App2Web flow through a real trigger.
+
+## Before you go live
+
+Run through the [App2Web go-live checklist](/guides/app2web-go-live-checklist) before sending traffic to this flow.

--- a/guides/stripe-onboarding-guide.mdx
+++ b/guides/stripe-onboarding-guide.mdx
@@ -256,3 +256,4 @@ Deep links are specific to your app build, so it's cleaner to configure them alo
 - **Availability:** Stripe App2Web is currently supported for US storefronts only.
 - **Publish states:** both the original paywall and its linked hosted web paywall must be published before the flow works end-to-end.
 - **Localizations:** hosted web paywalls currently support one language.
+- **Testing:** normally, paywalls should be tested with the triple-tap viewer. Triple-tap does not currently support end-to-end App2Web testing, so test the full App2Web flow through a real trigger.


### PR DESCRIPTION
## What changed
- Make Paddle and Stripe App2Web testing practical for sandbox/debug targeting and browser handoff.
- Add a shared, unlisted App2Web go-live checklist linked from both onboarding guides.
- Clarify purchase-action browser navigation, product continuity, IAP fallback, and end-to-end testing.
- Correct current limitations and clarify that triple-tap does not test App2Web end to end.

## Validation
- `git diff --cached --check`
- `git show --check`
- `docs.json` unchanged