### PR TITLE
Add Helium rollout and QA guides

### DIFF
--- a/guides/helium-qa-guide.mdx
+++ b/guides/helium-qa-guide.mdx
@@ -1,0 +1,41 @@
+---
+title: "Helium QA Guide"
+description: "A short checklist for testing your Helium paywalls before launch."
+---
+
+Use this checklist after your paywalls are built and before starting your rollout.
+
+<Note>
+  Complete QA for the normal in-app purchase path first. If you also use App2Web, approve the IAP path before testing the full App2Web flow.
+</Note>
+
+## Check the dashboard
+
+- [ ] Apps and products are synced for each platform, and product IDs match the stores.
+- [ ] The intended products, default selection, and trial states are attached and published.
+- [ ] Each workflow trigger, targeting rule, and fallback points to the intended paywall.
+- [ ] Analytics and revenue integrations are receiving test events.
+
+## Check the paywall
+
+- [ ] Design, copy, products, and pricing match the approved experience.
+- [ ] Purchase, close, restore, and second-tier actions work.
+- [ ] Trial states, variables, user attributes, and custom actions work when used.
+- [ ] Product selection and purchase use separate actions so a user cannot buy the wrong product.
+- [ ] Check a few currencies, every supported language, a small phone, and dark mode when relevant.
+- [ ] The paywall opens without visual flashes or broken animations.
+
+## Test on device
+
+- [ ] Use the intended TestFlight or Android build on a physical device for each platform.
+- [ ] Open every launch-critical trigger and confirm the correct paywall appears.
+- [ ] Complete a sandbox purchase and confirm the correct product is purchased and access unlocks.
+- [ ] Confirm cancel and restore behavior work.
+- [ ] Confirm the purchase and entitlement appear in your analytics or revenue system.
+- [ ] Confirm a current fallback paywall appears when Helium configuration cannot load.
+
+## Ready to launch
+
+- [ ] The release build uses the correct Helium environment and API key.
+- [ ] Open issues are documented and the final paywalls are approved.
+- [ ] Start with a small group of users using the [Helium rollout guide](/guides/rolling-out-helium).

--- a/guides/rolling-out-helium.mdx
+++ b/guides/rolling-out-helium.mdx
@@ -1,0 +1,40 @@
+---
+title: "Rolling Out Helium"
+description: "A simple guide for rolling out Helium and monitoring performance."
+---
+
+Here are our tips for rolling out Helium smoothly. Start small, make sure the basics are working, and ramp up from there.
+
+## Set up the rollout
+
+Use your existing feature flag or experimentation tool to split users between your current paywall and Helium. PostHog, Statsig, Firebase Remote Config, LaunchDarkly, or your own feature flag system all work.
+
+For an A/A comparison, keep the paywall design, products, targeting, and purchase behavior as similar as possible between the two groups.
+
+<Tip>
+  Initialize Helium at app launch for all users. Use the feature flag to decide whether a user sees the current experience or Helium.
+</Tip>
+
+## Start small
+
+First, test with internal or allowlisted users. Confirm the paywall opens and dismisses correctly, the right products appear, purchases work, and analytics are flowing.
+
+Then roll Helium out to a small percentage of users, usually around 5%, for 24-48 hours. This is mostly a check that everything works in production.
+
+## Watch the basics
+
+Loosely monitor:
+
+- Users assigned to each rollout group
+- Paywall views in each group
+- Paywall conversion rate in each group
+- Purchase errors, app errors, and Helium fallback rate
+- Helium Analytics for each paywall and trigger
+
+The numbers do not need to match perfectly. You are looking for obvious gaps, missing events, or a meaningful drop in conversion.
+
+## Ramp up
+
+Once everything looks healthy, you can roll Helium out to everyone.
+
+If you want to confirm conversion is maintained first, move to a 50/50 split between your current experience and Helium. Run it long enough to get a useful amount of conversion data for your traffic level, then complete the rollout.

--- a/guides/rolling-out-helium.mdx
+++ b/guides/rolling-out-helium.mdx
@@ -21,20 +21,21 @@ First, test with internal or allowlisted users. Confirm the paywall opens and di
 
 Then roll Helium out to a small percentage of users, usually around 5%, for 24-48 hours. This is mostly a check that everything works in production.
 
-## Watch the basics
+## Validate the data
 
-Loosely monitor:
+At this stage, make sure:
 
-- Users assigned to each rollout group
-- Paywall views in each group
-- Paywall conversion rate in each group
-- Purchase errors, app errors, and Helium fallback rate
-- Helium Analytics for each paywall and trigger
+- Data is showing up in Helium
+- Paywall views and conversions are being recorded
+- Analytics are flowing for each paywall and trigger
+- Error logs do not show any new problems
 
-The numbers do not need to match perfectly. You are looking for obvious gaps, missing events, or a meaningful drop in conversion.
+This step is about confirming the data is working, not comparing aggregate performance yet.
 
 ## Ramp up
 
 Once everything looks healthy, you can roll Helium out to everyone.
 
-If you want to confirm conversion is maintained first, move to a 50/50 split between your current experience and Helium. Run it long enough to get a useful amount of conversion data for your traffic level, then complete the rollout.
+If you want to confirm conversion is maintained first, move to a 50/50 split between your current experience and Helium. At that point, loosely compare the users in each rollout group, paywall views, and paywall conversion rate.
+
+Run it long enough to get a useful amount of conversion data for your traffic level, then complete the rollout.


### PR DESCRIPTION
## What changed
- Add a short customer-facing guide for rolling out Helium.
- Add a concise pre-launch QA checklist based on Helium internal QA and common RevenueCat/Superwall launch checks.
- Keep both pages unlisted by leaving `docs.json` unchanged.

## Validation
- `git diff --cached --check`
- `git show --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no application, API, or configuration changes.
> 
> **Overview**
> Adds two new customer-facing MDX guides under `guides/`: a **pre-launch QA checklist** (`helium-qa-guide.mdx`) and a **rollout playbook** (`rolling-out-helium.mdx`).
> 
> The QA page walks through dashboard config, paywall behavior, on-device sandbox testing, and launch readiness, and links to the rollout guide for the final step. The rollout page covers feature-flag setup, internal → ~5% → data validation → optional 50/50 → full rollout, with tips on initializing Helium for all users while gating the UI via flags.
> 
> Neither page is wired into the public docs nav (`docs.json` unchanged), so they remain discoverable by direct URL or internal links only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8273cc0babfaf3fed014814fe14167cf0470baba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->