### PR TITLE
[HEL-6492] | Android data safety audit

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -41,7 +41,8 @@
           "guides/custom-events",
           "guides/storekit-testing",
           "guides/paywall-traits",
-          "guides/paddle-onboarding-guide"
+          "guides/paddle-onboarding-guide",
+          "guides/google-play-data-safety"
         ]
       },
       {

--- a/guides/google-play-data-safety.mdx
+++ b/guides/google-play-data-safety.mdx
@@ -138,27 +138,11 @@ Two Helium modules change your answers if you use them.
 
     Using this module means RevenueCat's own data collection applies to your app as well. Refer to [RevenueCat's Data Safety guidance](https://www.revenuecat.com/docs/platform-resources/google-platform-resources/google-plays-data-safety) alongside this page.
   </Tab>
-  <Tab title="Stripe">
-    The `stripe` module collects billing **name**, **email address**, and **full billing address** during checkout, and sends them to Helium to create the payment intent.
-
-    If you use it, add these to your declaration:
-
-    - Personal info → **Name**, **Email address**, **Address**
-    - Financial info → **User payment info**
-
-    Card numbers are handled inside Stripe's SDK and never reach Helium, which receives only a payment method token. Refer to Stripe's own data safety guidance as well.
-  </Tab>
 </Tabs>
 
 ## What's next
 
 <CardGroup cols={2}>
-  <Card title="Events and Fields" icon="chart-mixed" href="/guides/third-party-analytics">
-    The full list of events and fields Helium sends, useful for reviewing exactly what is collected
-  </Card>
-  <Card title="Download Full Field List" icon="download" href="/files/helium-event-fields.json">
-    A JSON file containing every event field name, type, and description
-  </Card>
   <Card title="Identifying Users" icon="android" href="/sdk/quickstart-android">
     How `Helium.identity.userId` and `HeliumUserTraits` work, which drive the conditional rows above
   </Card>

--- a/guides/google-play-data-safety.mdx
+++ b/guides/google-play-data-safety.mdx
@@ -45,7 +45,7 @@ On the client, `Helium.resetHelium()` clears the locally persisted Helium identi
 | Category | Data type | Required? |
 | --- | --- | --- |
 | Location | Approximate location, Precise location | ❌ Helium reads no location APIs and declares no location permission. It collects device locale, currency, and Play store country, which Google does not classify as location. |
-| Personal info | **User IDs** | ✅ Helium generates a persistent installation ID, plus per-session and per-initialization IDs. Includes your own `Helium.identity.userId` if you set one. |
+| Personal info | User IDs | 💡 Only if you set `Helium.identity.userId`, `revenueCatAppUserId`, or `thirdPartyAnalyticsAnonymousId` to a value that relates to an identifiable person, such as your own account ID. If you set none of them, Helium falls back to its generated installation ID, which is covered by Device or other IDs below. |
 | Personal info | Name, Email address, Phone number, Address | 💡 Only if you put them into `HeliumUserTraits`, or if you use the optional Stripe module. |
 | Financial info | **Purchase history** | ✅ Helium collects product IDs, Google Play order IDs and purchase tokens, purchase dates, quantity, and store country. |
 | Financial info | User payment info | 💡 Optional Stripe module only. |
@@ -63,21 +63,28 @@ On the client, `Helium.resetHelium()` clears the locally persisted Helium identi
 | Web browsing | Web browsing history | ❌ Paywalls render inside a WebView that loads Helium-controlled content. Helium does not read browsing history. |
 | App info and performance | **Diagnostics** | ✅ Paywall load and render timings, configuration download outcomes, retry counts, and error descriptions. |
 | App info and performance | Crash logs, Other app performance data | ❌ Helium bundles no crash reporter. |
-| Device or other IDs | **Device or other IDs** | ✅ Helium collects the Android ID (`Settings.Secure.ANDROID_ID`) and its own persistent installation ID. |
+| Device or other IDs | **Device or other IDs** | ✅ The Android ID (`Settings.Secure.ANDROID_ID`), plus Helium's own generated installation, session, and initialization IDs. |
 
 <Tip>
-  Helium declares more than a billing-only SDK would, because paywall interaction data is what powers experiments and optimization rather than being a side effect. The five bolded rows above are the ones you always need.
+  Helium declares more than a billing-only SDK would, because paywall interaction data is what powers experiments and optimization rather than being a side effect. The four bolded rows above are the ones you always need.
 </Tip>
 
 ## Answering the per-data-type questions
 
-For each data type you select, Google asks four follow-up questions. All five required Helium data types (User IDs, Purchase history, App interactions, Diagnostics, and Device or other IDs) get the same answers.
+For each data type you select, Google asks four follow-up questions. All four required Helium data types (Purchase history, App interactions, Diagnostics, and Device or other IDs) get the same answers. Any 💡 rows that apply to your setup generally follow the same pattern, though review the purposes for your own case.
 
 ### Is this data collected, shared, or both?
 
-Select **Collected**.
+Select **Collected** if Helium processes this data solely on your behalf and under your instructions. That is Google's test for a service provider, and sharing does not apply.
 
-Helium processes this data on your behalf, as a service provider under Google's definition, so sharing does not apply by default. If you route Helium events onward to third parties that are not acting as your service providers, you may also need to select **Shared** and declare the purposes of that sharing.
+Select **Collected** and **Shared**, and declare the purposes of that sharing, if either of the following is true:
+
+- Helium uses your app's data for its own cross-customer optimization or experiment purposes rather than solely on your instructions.
+- You forward Helium events to third parties that are not acting as your service providers.
+
+<Warning>
+  Google is explicit that "if an SDK provider is building advertising profiles across multiple customers based on your app data, that would not be considered 'service provider' activity." Confirm which of the above describes your contract and configuration before answering.
+</Warning>
 
 ### Is this data processed ephemerally?
 
@@ -88,8 +95,12 @@ Select **No**. Helium retains this data to power paywall experimentation and rep
 Select **Data collection is required** by default. The Helium SDK does not expose a per-user opt-out, so once you initialize it, collection begins.
 
 <Tip>
-  You can declare this data **optional** instead if you gate `Helium.initialize()` behind your own consent prompt and only call it for users who agree. Google's bar is that all users, regardless of device or region, must be able to opt in or out. This is worth doing if you operate in regions with consent requirements, since it also gives you a clean GDPR and CCPA story.
+  You can declare this data **optional** instead if you gate `Helium.initialize()` behind your own consent prompt and only call it for users who agree. Google's bar is that all users, regardless of device or region, must be able to opt in or out.
 </Tip>
+
+<Note>
+  A consent gate answers this Play Data safety question only. It does not by itself establish compliance with GDPR, CCPA, or other privacy regimes, which impose separate requirements such as having a lawful basis for processing, giving notice at collection, and handling consumer rights requests. Review the jurisdictions you operate in with privacy counsel.
+</Note>
 
 ### Why is this user data collected?
 

--- a/guides/google-play-data-safety.mdx
+++ b/guides/google-play-data-safety.mdx
@@ -1,0 +1,157 @@
+---
+title: "Google Play Data Safety (Android)"
+description: "What to declare in your Play Console Data safety section when your app includes the Helium Android SDK."
+icon: "shield-halved"
+---
+
+Google Play requires every developer to declare how their app collects and handles user data, **including data handled by any third-party SDK they bundle**. This page tells you which boxes to tick in the Play Console **Data safety** section when your app includes the Helium Android SDK.
+
+<Note>
+  Google is explicit that the declaration is yours to make: "You alone are responsible for making complete and accurate declarations in your app's store listing on Google Play." This page covers the Helium SDK only. Your final declaration must also account for your own app's data collection and every other SDK you ship.
+</Note>
+
+## Data collection and security
+
+Three questions gate the rest of the form.
+
+### Does your app collect or share any of the required user data types?
+
+Select **Yes**. Helium collects a device identifier, purchase history, and paywall interaction data.
+
+### Is all of the user data collected by your app encrypted in transit?
+
+Select **Yes** as far as Helium is concerned. All Helium network traffic uses HTTPS.
+
+<Warning>
+  Google only lets you select "Yes" if encryption in transit applies to **all** user data your app and every one of its SDKs transmits off the device. Confirm this holds across your whole app before selecting it.
+</Warning>
+
+### Do you provide a way for users to request that their data is deleted?
+
+This one depends on your own support process, not on Helium. If you select **Yes**, make sure users have a route to reach you, such as an in-app link, a contact form, or a support email.
+
+On the client, `Helium.resetHelium()` clears the locally persisted Helium identity and user traits. For deletion of data already sent to Helium, contact Helium support.
+
+## Data types
+
+<Info>
+  ✅ Required when using Helium
+
+  💡 May be required, depending on how you configure the SDK
+
+  ❌ Not collected by Helium
+</Info>
+
+| Category | Data type | Required? |
+| --- | --- | --- |
+| Location | Approximate location, Precise location | ❌ Helium reads no location APIs and declares no location permission. It collects device locale, currency, and Play store country, which Google does not classify as location. |
+| Personal info | **User IDs** | ✅ Helium generates a persistent installation ID, plus per-session and per-initialization IDs. Includes your own `Helium.identity.userId` if you set one. |
+| Personal info | Name, Email address, Phone number, Address | 💡 Only if you put them into `HeliumUserTraits`, or if you use the optional Stripe module. |
+| Financial info | **Purchase history** | ✅ Helium collects product IDs, Google Play order IDs and purchase tokens, purchase dates, quantity, and store country. |
+| Financial info | User payment info | 💡 Optional Stripe module only. |
+| Financial info | Credit score, Other financial info | ❌ |
+| Health and fitness | All types | ❌ |
+| Messages | All types | ❌ |
+| Photos and videos | All types | ❌ |
+| Audio files | All types | ❌ |
+| Files and docs | Files and docs | ❌ |
+| Calendar | Calendar events | ❌ |
+| Contacts | Contacts | ❌ |
+| App activity | **App interactions** | ✅ Paywall opens, closes and dismissals, button presses, product selection, purchase flow steps, and experiment allocation. |
+| App activity | Other actions | 💡 Only if your paywalls emit custom actions carrying additional user activity. |
+| App activity | In-app search history, Installed apps, Other user-generated content | ❌ |
+| Web browsing | Web browsing history | ❌ Paywalls render inside a WebView that loads Helium-controlled content. Helium does not read browsing history. |
+| App info and performance | **Diagnostics** | ✅ Paywall load and render timings, configuration download outcomes, retry counts, and error descriptions. |
+| App info and performance | Crash logs, Other app performance data | ❌ Helium bundles no crash reporter. |
+| Device or other IDs | **Device or other IDs** | ✅ Helium collects the Android ID (`Settings.Secure.ANDROID_ID`) and its own persistent installation ID. |
+
+<Tip>
+  Helium declares more than a billing-only SDK would, because paywall interaction data is what powers experiments and optimization rather than being a side effect. The five bolded rows above are the ones you always need.
+</Tip>
+
+## Answering the per-data-type questions
+
+For each data type you select, Google asks four follow-up questions. All five required Helium data types (User IDs, Purchase history, App interactions, Diagnostics, and Device or other IDs) get the same answers.
+
+### Is this data collected, shared, or both?
+
+Select **Collected**.
+
+Helium processes this data on your behalf, as a service provider under Google's definition, so sharing does not apply by default. If you route Helium events onward to third parties that are not acting as your service providers, you may also need to select **Shared** and declare the purposes of that sharing.
+
+### Is this data processed ephemerally?
+
+Select **No**. Helium retains this data to power paywall experimentation and reporting.
+
+### Is this data required for your app, or can users choose whether it's collected?
+
+Select **Data collection is required** by default. The Helium SDK does not expose a per-user opt-out, so once you initialize it, collection begins.
+
+<Tip>
+  You can declare this data **optional** instead if you gate `Helium.initialize()` behind your own consent prompt and only call it for users who agree. Google's bar is that all users, regardless of device or region, must be able to opt in or out. This is worth doing if you operate in regions with consent requirements, since it also gives you a clean GDPR and CCPA story.
+</Tip>
+
+### Why is this user data collected?
+
+Select **App functionality** and **Analytics**.
+
+<Note>
+  Also select **Personalization** if you use audience targeting or experiment rules that tailor which paywall a user sees based on traits you provide.
+</Note>
+
+## What Helium does not collect
+
+Worth knowing, because it keeps several categories off your form entirely:
+
+- **No advertising identifier.** Helium does not read the Google Advertising ID or App Set ID, and declares no `com.google.android.gms.permission.AD_ID` permission.
+- **No location.** No location APIs, no location permissions.
+- **No contacts, photos, videos, audio, files, calendar, or messages.**
+- **No crash logs.** Helium bundles no crash reporting library.
+- **No health or fitness data.**
+
+The SDK contributes only these permissions to your merged manifest:
+
+| Permission | Why |
+| --- | --- |
+| `android.permission.INTERNET` | Fetching paywall configuration and bundles |
+| `android.permission.ACCESS_NETWORK_STATE` | Detecting connectivity before network calls |
+| `com.android.vending.BILLING` | Google Play Billing, for purchases and entitlements |
+
+## Optional modules
+
+Two Helium modules change your answers if you use them.
+
+<Tabs>
+  <Tab title="RevenueCat">
+    The `revenue-cat` module sets Helium's persistent installation ID as the RevenueCat app user ID, and by default also as a `helium_hpid` subscriber attribute. You can turn the attribute off by constructing the delegate with `allowHeliumUserAttribute = false`.
+
+    Using this module means RevenueCat's own data collection applies to your app as well. Refer to [RevenueCat's Data Safety guidance](https://www.revenuecat.com/docs/platform-resources/google-platform-resources/google-plays-data-safety) alongside this page.
+  </Tab>
+  <Tab title="Stripe">
+    The `stripe` module collects billing **name**, **email address**, and **full billing address** during checkout, and sends them to Helium to create the payment intent.
+
+    If you use it, add these to your declaration:
+
+    - Personal info → **Name**, **Email address**, **Address**
+    - Financial info → **User payment info**
+
+    Card numbers are handled inside Stripe's SDK and never reach Helium, which receives only a payment method token. Refer to Stripe's own data safety guidance as well.
+  </Tab>
+</Tabs>
+
+## What's next
+
+<CardGroup cols={2}>
+  <Card title="Events and Fields" icon="chart-mixed" href="/guides/third-party-analytics">
+    The full list of events and fields Helium sends, useful for reviewing exactly what is collected
+  </Card>
+  <Card title="Download Full Field List" icon="download" href="/files/helium-event-fields.json">
+    A JSON file containing every event field name, type, and description
+  </Card>
+  <Card title="Identifying Users" icon="android" href="/sdk/quickstart-android">
+    How `Helium.identity.userId` and `HeliumUserTraits` work, which drive the conditional rows above
+  </Card>
+  <Card title="Google's Official Guidance" icon="shield-halved" href="https://support.google.com/googleplay/android-developer/answer/10787469">
+    Play Console documentation for the Data safety section
+  </Card>
+</CardGroup>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, SDK, or security behavior impact.
> 
> **Overview**
> Adds a new **Google Play Data Safety (Android)** guide that walks developers through Play Console declarations when the Helium Android SDK is bundled.
> 
> The page covers the top-level security questions, a data-type matrix (required vs conditional vs not collected), per-type follow-ups (collected/shared, ephemeral processing, required vs optional, purposes), what Helium does **not** collect, merged manifest permissions, and optional **RevenueCat** module implications. It also documents `Helium.resetHelium()` for local identity clearing and points readers to Helium support for server-side deletion.
> 
> **`docs.json`** links the guide under the guides section (and adds a trailing comma after the Paddle onboarding entry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b43c6a3b51b66c49687bcf80a74812d9818e5ece. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Google Play Data Safety guide for apps using the Helium Android SDK.
  * Documented data collection, encryption, deletion, retention, sharing, opt-out, and purpose declarations.
  * Listed collected and excluded data, required permissions, and RevenueCat-specific considerations.
  * Added the guide to the documentation navigation and linked related resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->