### PR TITLE
Fix Flutter web checkout snippets and expand deep link and testing guidance

### DIFF
--- a/guides/paddle-onboarding-guide.mdx
+++ b/guides/paddle-onboarding-guide.mdx
@@ -21,7 +21,7 @@ By the end of this guide, you'll have:
 Before you start, make sure you have:
 
 - A Paddle account. If you don't have one, start with Paddle's [setup checklist](https://developer.paddle.com/build/onboarding/set-up-checklist#sign-up) and [onboarding overview](https://developer.paddle.com/build/onboarding/overview).
-- The Helium iOS SDK already integrated in your app.
+- The Helium SDK (iOS native, React Native/Expo, or Flutter) already integrated in your app.
 - A deep link scheme configured in your app â€” users need a way back into your app after purchase.
 - Admin access to your Helium dashboard.
 - (Optional) A RevenueCat account, if you want Paddle purchases to reflect in RevenueCat entitlements.
@@ -92,7 +92,7 @@ The hosted web paywall doesn't have to show the same products as the original â€
 ### 7. SDK integration
 
 <Tabs>
-  <Tab title="iOS (native) 4.6.0+">
+  <Tab title="iOS (native, Helium 4.6.0+)">
     **Enable external web checkout before initializing Helium:**
 
     ```swift
@@ -193,7 +193,7 @@ The hosted web paywall doesn't have to show the same products as the original â€
 
     Send that ID to your server and follow [Paddle's guide for generating pre-authenticated customer portal links](https://developer.paddle.com/build/customers/integrate-customer-portal/).
   </Tab>
-  <Tab title="Flutter 3.3.8+">
+  <Tab title="Flutter (Helium 3.3.8+)">
     **Enable external web checkout before initializing Helium:**
 
     ```dart
@@ -201,34 +201,57 @@ The hosted web paywall doesn't have to show the same products as the original â€
       successURL: "yourapp://openapp",
       cancelURL: "yourapp://openapp",
       paymentProcessors: {HeliumWebCheckoutProcessor.paddle},
-    )
+    );
     ```
 
-    The `successURL` and `cancelURL` are set once, globally. Make sure both are registered as deep links in your app (via scheme or universal link).
+    The `successURL` and `cancelURL` are set once, globally.
+
+    **Register the deep link.** Both URLs must be registered as deep links in your app. For a custom scheme, add a `CFBundleURLTypes` entry to `ios/Runner/Info.plist`:
+
+    ```xml
+    <key>CFBundleURLTypes</key>
+    <array>
+      <dict>
+        <key>CFBundleURLName</key>
+        <string>com.yourcompany.yourapp</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
+          <string>yourapp</string>
+        </array>
+      </dict>
+    </array>
+    ```
+
+    To use a universal link (`https://...`) instead, set up [associated domains](https://docs.flutter.dev/ui/navigation/deep-linking) and use that URL as the `successURL`/`cancelURL`.
 
     **Set your user ID on Helium** before the user reaches a paywall. If you must set user ID after showing a paywall, make sure to call `setAllowWebCheckoutWithoutUserId(true)`.
 
-    **Handle the post-purchase return.** When checkout completes, the user is deep-linked back to your app via the success URL. For a smoother handoff, call `handleURL(url)` from your deep link handling:
+    **Handle the post-purchase return.** When checkout completes, the user is deep-linked back to your app via the success URL. Forward incoming links to Helium with `handleURL(url)` â€” it's safe to forward every link, since URLs that aren't Helium's are ignored. If you don't already handle deep links, add [app_links](https://pub.dev/packages/app_links) with `flutter pub add app_links`:
 
     ```dart
+    import 'package:app_links/app_links.dart';
+
     _linkSubscription = AppLinks().uriLinkStream.listen((uri) {
       HeliumFlutter().handleURL(uri.toString());
     });
     ```
 
-    **Add a "Manage Subscription" button** so users can cancel or update payment methods via Paddle's customer portal:
+    <Note>
+      `uriLinkStream` also emits the link that launched the app, so cold starts are covered â€” there is no separate initial-link step. If you use `app_links`, set `FlutterDeepLinkingEnabled` to `false` in `Info.plist` so Flutter's built-in deep-link handling doesn't consume the link first.
+    </Note>
+
+    **Add a "Manage Subscription" button** so users can cancel or update payment methods via Paddle's customer portal. `launchUrl` comes from the [url_launcher](https://pub.dev/packages/url_launcher) package:
 
     ```dart
     final hasPaddle = await HeliumFlutter().hasActivePaddleEntitlement();
     if (hasPaddle) {
         // show the manage subscription button
     }
-    
+
     // when the button is tapped:
-    final url = await HeliumFlutter().createPaddlePortalSession();
-    if (url != null) {
-      final Uri url = Uri.parse(url);
-      await launchUrl(url);
+    final urlString = await HeliumFlutter().createPaddlePortalSession();
+    if (urlString != null) {
+      await launchUrl(Uri.parse(urlString));
     }
     ```
 
@@ -292,6 +315,10 @@ Target the App2Web paywall to that group, then run through these scenarios in Pa
 5. **Webhook delivery.** In the Paddle dashboard, confirm webhooks are reaching Helium with 2xx responses.
 6. **Pre-login purchase (if applicable).** If your App2Web paywall can be shown before you set a durable `user_id`, make a purchase before setting it. Set the durable user ID afterwards and confirm the entitlement attaches correctly.
 
+<Note>
+  **App2Web paywall not appearing?** Eligibility is checked server-side against the device's locale country, App Store storefront country, and IP location â€” all three must be US, and there is no client-side error when a device is filtered out. If you're testing from the US, disable VPNs. If you're testing from outside the US: set your device region to the United States, sign in with a sandbox Apple account on the US storefront, and connect through a US VPN so your IP resolves to the US.
+</Note>
+
 ## Appendix
 
 ### How entitlements work
@@ -306,7 +333,7 @@ The original in-app paywall presents your Paddle offerings. The hosted web paywa
 
 ### Known limitations and gotchas
 
-- **Availability:** Paddle App2Web is currently supported for US storefronts only.
+- **Availability:** Paddle App2Web is currently iOS-only and supported for US storefronts only. iOS-only applies across all SDKs â€” in React Native and Flutter apps, the web-checkout APIs are safe no-ops on Android, so shared code can ship unchanged and Android users keep your regular in-app purchase flow.
 - **California compliance** for subscription cancellation: guidance coming soon.
 - **Publish states:** both the original paywall and its linked hosted web paywall must be published before the flow works end-to-end.
 - **Localizations:** hosted web paywalls currently support one language.

--- a/guides/stripe-onboarding-guide.mdx
+++ b/guides/stripe-onboarding-guide.mdx
@@ -60,7 +60,7 @@ The hosted web paywall doesn't have to show the same products as the original â€
 ### 4. SDK integration
 
 <Tabs>
-  <Tab title="iOS (native) 4.6.0+">
+  <Tab title="iOS (native, Helium 4.6.0+)">
     **Enable external web checkout before initializing Helium:**
 
     ```swift
@@ -96,7 +96,7 @@ The hosted web paywall doesn't have to show the same products as the original â€
     }
     ```
   </Tab>
-  <Tab title="Expo 3.4.13+">
+  <Tab title="Expo (Helium 3.4.13+)">
     **Enable external web checkout before initializing Helium:**
 
     ```tsx
@@ -139,7 +139,7 @@ The hosted web paywall doesn't have to show the same products as the original â€
     }
     ```
   </Tab>
-  <Tab title="Flutter 3.3.8+">
+  <Tab title="Flutter (Helium 3.3.8+)">
     **Enable external web checkout before initializing Helium:**
 
     ```dart
@@ -147,7 +147,7 @@ The hosted web paywall doesn't have to show the same products as the original â€
       successURL: "yourapp://openapp",
       cancelURL: "yourapp://openapp",
       paymentProcessors: {HeliumWebCheckoutProcessor.stripe},
-    )
+    );
     ```
 
     The `successURL` and `cancelURL` are set once, globally. Make sure both are registered as deep links in your app (via scheme or universal link).
@@ -170,11 +170,13 @@ The hosted web paywall doesn't have to show the same products as the original â€
         // show the manage subscription button
     }
     
-    // when the button is tapped:
-    final urlString = await HeliumFlutter().createStripePortalSession();
+    // when the button is tapped â€” returnUrl is where Stripe sends the user
+    // back after they're done managing their subscription:
+    final urlString = await HeliumFlutter().createStripePortalSession(
+      returnUrl: "yourapp://openapp",
+    );
     if (urlString != null) {
-      final Uri url = Uri.parse(url);
-      await launchUrl(url);
+      await launchUrl(Uri.parse(urlString));
     }
     ```
   </Tab>


### PR DESCRIPTION
Stacked on the SDK-52 docs branch — do not merge before it; retarget to main once it lands.

Validated the Paddle/Stripe onboarding guides' Flutter sections against the helium_flutter SDK (3.3.8) and fixed what didn't hold up (HEL-6568):

Compile fixes (all snippet forms verified with dart analyze):
- Paddle + Stripe: missing semicolon after enableExternalWebCheckout(...)
- Paddle + Stripe: "Manage Subscription" snippet self-referenced `url` in its own declaration (referenced_before_declaration)
- Stripe: createStripePortalSession() was called with no arguments; the SDK requires returnUrl

Gaps filled:
- Known limitations now state App2Web is iOS-only across all SDKs, with web-checkout calls being safe no-ops on Android
- Flutter tab: deep link registration steps (CFBundleURLTypes / universal links), app_links and url_launcher install notes, cold-start behavior of uriLinkStream, and the FlutterDeepLinkingEnabled=false gotcha
- Testing: troubleshooting note for the paywall not appearing — locale, storefront, and IP must all be US, including how to test from outside the US
- Prerequisites made platform-neutral; SDK tab titles now prefixed with "Helium" so version floors read as SDK versions, not platform versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to MDX documentation with no runtime or API code paths affected.
> 
> **Overview**
> Updates the **Paddle** and **Stripe** App2Web onboarding guides so copy-paste Flutter (and tab) examples match the Helium SDK and cover common integration pitfalls.
> 
> **Snippet fixes:** Flutter `enableExternalWebCheckout` examples now end with a semicolon; Paddle’s manage-subscription sample no longer reuses `url` in its own initializer; Stripe Flutter docs now call `createStripePortalSession(returnUrl: ...)` instead of a zero-arg call.
> 
> **Paddle guide expansions:** Prerequisites and tab titles are platform-neutral and label Helium version floors clearly. The Flutter section adds **deep link** setup (`Info.plist` / universal links), **`app_links`** + **`url_launcher`** usage, cold-start / `FlutterDeepLinkingEnabled` notes, and clarifies that App2Web is **iOS-only** (web-checkout APIs are safe no-ops on Android). Testing adds troubleshooting when the App2Web paywall never appears (US locale, storefront, and IP).
> 
> **Stripe guide:** Same tab-title tweak and Flutter semicolon fix; Flutter portal snippet updated for required `returnUrl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c540ffd6320bf1215e232d94584677ed7ae905b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->